### PR TITLE
Initial accelerometer support, standalone tap, cap touch components. Example initialization for rest of components.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -217,7 +217,7 @@ Playground.Tap = function(io) {
   this.callbacks_ = [];
   this.io_ = io;
 
-  replyHandlers[CP_ACCEL_TAP_REPLY] = function (data) {
+  replyHandlers[CP_ACCEL_TAP_REPLY] = function(data) {
     if (data.length < 4) {
       console.log('Received tap response with not enough data!');
       return;

--- a/lib/index.js
+++ b/lib/index.js
@@ -197,7 +197,7 @@ Playground.CapTouch = function (io) {
     var value = Playground.parseFirmataLong(data.slice(4,12));
 
     if (this.callbacks_[inputPin]) {
-      this.callbacks_[inputPin](inputPin, value > CAP_THRESHOLD, value);
+      this.callbacks_[inputPin](value > CAP_THRESHOLD, value);
     }
   }.bind(this);
 };
@@ -225,13 +225,13 @@ Playground.Tap = function (io) {
     }
 
     var register = Playground.parseFirmataByte(data.slice(2,4));
-    var hasAny = (register & 0x30 > 0);
-    var single = hasAny && (register & 0x10 > 0);
-    var double = hasAny && (register & 0x20 > 0);
+    var hasAnyTap = (register & 0x30) > 0;
+    var hasSingleTap = hasAnyTap && ((register & 0x10) > 0);
+    var hasDoubletap = hasAnyTap && ((register & 0x20) > 0);
 
     if (this.callbacks_.length) {
-      this.callbacks_.forEach(function (cb) {
-        cb(single, double);
+      this.callbacks_.forEach(function (callback) {
+        callback(hasSingleTap, hasDoubletap);
       }.bind(this));
     }
   }.bind(this);
@@ -239,11 +239,11 @@ Playground.Tap = function (io) {
 
 Playground.Tap.prototype.onTap = function (callback) {
   this.callbacks_.push(callback);
-  this.io_.sysexCommand([CP_COMMAND, CP_ACCEL_TAP_ON]);
+  this.io_.sysexCommand([CP_COMMAND, CP_ACCEL_TAP_STREAM_ON]);
 };
 
 Playground.Tap.prototype.stop = function () {
-  this.io_.sysexCommand([CP_COMMAND, CP_ACCEL_TAP_OFF]);
+  this.io_.sysexCommand([CP_COMMAND, CP_ACCEL_TAP_STREAM_OFF]);
   this.callbacks_.length = 0;
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -140,7 +140,7 @@ function parseFirmata(data, format) {
   return bufferpack.unpack(format, rawBytes)[0];
 }
 
-Playground.Gyro = {
+Playground.Accelerometer = {
   initialize: {
     value: function (opts, dataHandler) {
       replyHandlers[CP_ACCEL_READ_REPLY] = function(data) {
@@ -151,15 +151,8 @@ Playground.Gyro = {
         var x = Playground.parseFirmataFloat(data.slice(2, 10));
         var y = Playground.parseFirmataFloat(data.slice(10, 18));
         var z = Playground.parseFirmataFloat(data.slice(18, 26));
-        var gyroDataObject = {x: x, y: y, z: z};
-        dataHandler(gyroDataObject);
+        dataHandler({x: x, y: y, z: z});
       };
-    }
-  },
-  toNormal: {
-    // TODO: fill in, verify
-    value: function (raw) {
-      return raw;
     }
   },
   start: {
@@ -170,14 +163,6 @@ Playground.Gyro = {
   stop: {
     value: function () {
       this.io.sysexCommand([CP_COMMAND, CP_ACCEL_STREAM_OFF]);
-    }
-  },
-  toDegreesPerSecond: {
-    // TODO: fill in, verify
-    value: function (raw) {
-      // TODO: factor in sensitivity
-      //var state = priv.get(this);
-      return raw; /// state.sensitivity;
     }
   }
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -229,7 +229,7 @@ Playground.Tap = function (io) {
     var hasSingleTap = hasAnyTap && ((register & 0x10) > 0);
     var hasDoubletap = hasAnyTap && ((register & 0x20) > 0);
 
-    if (this.callbacks_.length) {
+    if (hasAnyTap && this.callbacks_.length) {
       this.callbacks_.forEach(function (callback) {
         callback(hasSingleTap, hasDoubletap);
       }.bind(this));

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,8 +39,7 @@ var THERM_NOMINAL_OHMS = 10000.0;  // Thermistor resistance at 25 degrees C.
 var THERM_NOMIMAL_C = 25.0;  // Thermistor temperature at nominal resistance.
 var THERM_BETA = 3950.0;  // Thermistor beta coefficient.
 var CAP_THRESHOLD = 300;  // Threshold for considering a cap touch input pressed.
-// If the cap touch value is above this value it is
-// considered touched.
+// If the cap touch value is above this value it is considered touched.
 
 function Playground(options) {
   Board.call(this, options.port);
@@ -106,7 +105,7 @@ Playground.Piezo = {
   }
 };
 
-Playground.parseFirmataByte = function (data) {
+Playground.parseFirmataByte = function(data) {
   // Parse a byte value from two 7-bit byte firmata response bytes.
   if (data.length != 2) {
     throw('Expected 2 bytes of firmata response for a byte value!');
@@ -144,9 +143,9 @@ function parseFirmata(data, format) {
 Playground.Gyro = {
   initialize: {
     value: function (opts, dataHandler) {
-      replyHandlers[CP_ACCEL_READ_REPLY] = function (data) {
+      replyHandlers[CP_ACCEL_READ_REPLY] = function(data) {
         if (data.length < 26) {
-          console.log('Received accelerometer response with not enough data!')
+          console.log('Received accelerometer response with not enough data!');
           return
         }
         var x = Playground.parseFirmataFloat(data.slice(2, 10));
@@ -183,11 +182,11 @@ Playground.Gyro = {
   }
 };
 
-Playground.CapTouch = function (io) {
+Playground.CapTouch = function(io) {
   this.callbacks_ = {};
   this.io_ = io;
 
-  replyHandlers[CP_CAP_REPLY] = function (data) {
+  replyHandlers[CP_CAP_REPLY] = function(data) {
     if (data.length < 12) {
       console.log('Received cap touch response with not enough data!');
       return;
@@ -202,19 +201,19 @@ Playground.CapTouch = function (io) {
   }.bind(this);
 };
 
-Playground.CapTouch.prototype.onTouch = function (pin, callback) {
+Playground.CapTouch.prototype.onTouch = function(pin, callback) {
   this.callbacks_[pin] = callback;
   this.io_.sysexCommand([CP_COMMAND, CP_CAP_ON, pin & 0x7F]);
 };
 
-Playground.CapTouch.prototype.stop = function () {
+Playground.CapTouch.prototype.stop = function() {
   this.callbacks_ = {};
   [0, 1, 2, 3, 6, 9, 10, 12].forEach(function(pin) {
     this.io_.sysexCommand([CP_COMMAND, CP_CAP_OFF, pin & 0x7F]);
   }.bind(this));
 };
 
-Playground.Tap = function (io) {
+Playground.Tap = function(io) {
   this.callbacks_ = [];
   this.io_ = io;
 
@@ -224,7 +223,7 @@ Playground.Tap = function (io) {
       return;
     }
 
-    var register = Playground.parseFirmataByte(data.slice(2,4));
+    var register = Playground.parseFirmataByte(data.slice(2, 4));
     var hasAnyTap = (register & 0x30) > 0;
     var hasSingleTap = hasAnyTap && ((register & 0x10) > 0);
     var hasDoubletap = hasAnyTap && ((register & 0x20) > 0);
@@ -237,12 +236,12 @@ Playground.Tap = function (io) {
   }.bind(this);
 };
 
-Playground.Tap.prototype.onTap = function (callback) {
+Playground.Tap.prototype.onTap = function(callback) {
   this.callbacks_.push(callback);
   this.io_.sysexCommand([CP_COMMAND, CP_ACCEL_TAP_STREAM_ON]);
 };
 
-Playground.Tap.prototype.stop = function () {
+Playground.Tap.prototype.stop = function() {
   this.io_.sysexCommand([CP_COMMAND, CP_ACCEL_TAP_STREAM_OFF]);
   this.callbacks_.length = 0;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -183,4 +183,68 @@ Playground.Gyro = {
   }
 };
 
+Playground.CapTouch = function (io) {
+  this.callbacks_ = {};
+  this.io_ = io;
+
+  replyHandlers[CP_CAP_REPLY] = function (data) {
+    if (data.length < 12) {
+      console.log('Received cap touch response with not enough data!');
+      return;
+    }
+
+    var inputPin = Playground.parseFirmataByte(data.slice(2,4));
+    var value = Playground.parseFirmataLong(data.slice(4,12));
+
+    if (this.callbacks_[inputPin]) {
+      this.callbacks_[inputPin](inputPin, value > CAP_THRESHOLD, value);
+    }
+  }.bind(this);
+};
+
+Playground.CapTouch.prototype.onTouch = function (pin, callback) {
+  this.callbacks_[pin] = callback;
+  this.io_.sysexCommand([CP_COMMAND, CP_CAP_ON, pin & 0x7F]);
+};
+
+Playground.CapTouch.prototype.stop = function () {
+  this.callbacks_ = {};
+  [0, 1, 2, 3, 6, 9, 10, 12].forEach(function(pin) {
+    this.io_.sysexCommand([CP_COMMAND, CP_CAP_OFF, pin & 0x7F]);
+  }.bind(this));
+};
+
+Playground.Tap = function (io) {
+  this.callbacks_ = [];
+  this.io_ = io;
+
+  replyHandlers[CP_ACCEL_TAP_REPLY] = function (data) {
+    if (data.length < 4) {
+      console.log('Received tap response with not enough data!');
+      return;
+    }
+
+    var register = Playground.parseFirmataByte(data.slice(2,4));
+    var hasAny = (register & 0x30 > 0);
+    var single = hasAny && (register & 0x10 > 0);
+    var double = hasAny && (register & 0x20 > 0);
+
+    if (this.callbacks_.length) {
+      this.callbacks_.forEach(function (cb) {
+        cb(single, double);
+      }.bind(this));
+    }
+  }.bind(this);
+};
+
+Playground.Tap.prototype.onTap = function (callback) {
+  this.callbacks_.push(callback);
+  this.io_.sysexCommand([CP_COMMAND, CP_ACCEL_TAP_ON]);
+};
+
+Playground.Tap.prototype.stop = function () {
+  this.io_.sysexCommand([CP_COMMAND, CP_ACCEL_TAP_OFF]);
+  this.callbacks_.length = 0;
+};
+
 module.exports = Playground;

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,10 +44,12 @@ var CAP_THRESHOLD = 300;  // Threshold for considering a cap touch input pressed
 
 function Playground(options) {
   Board.call(this, options.port);
-  this.io.sysexResponse(CP_COMMAND, function (data) {
-    var command = data[0] & 0x7F;
-    replyHandlers[command](data);
-  });
+  this.on("ready", function () {
+    this.sysexResponse(CP_COMMAND, function (data) {
+      var command = data[0] & 0x7F;
+      replyHandlers[command](data);
+    });
+  }.bind(this));
 }
 
 var replyHandlers = {};
@@ -144,9 +146,7 @@ Playground.Gyro = {
     value: function (opts, dataHandler) {
       console.log("Initializing gyro");
       this.io.sysexCommand([CP_COMMAND, CP_ACCEL_STREAM_ON]);
-      //this.io.sysexResponse(CP_ACCEL_READ_REPLY & 0x7F, function (data) {
-      // TODO: check for which command response this is?
-      this.io.sysexResponse(CP_COMMAND, function (data) {
+      replyHandlers[CP_ACCEL_READ_REPLY] = function (data) {
         if (data.length < 26) {
           console.log('Received accelerometer response with not enough data!')
           return
@@ -156,7 +156,7 @@ Playground.Gyro = {
         var z = Playground.parseFirmataFloat(data.slice(18, 26));
         var gyroDataObject = {x: x, y: y, z: z};
         dataHandler(gyroDataObject);
-      });
+      };
     }
   },
   toNormal: {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,15 +1,56 @@
 var Board = require("firmata");
+var bufferpack = require("bufferpack");
 
+// Constants that define the Circuit Playground Firmata command values.
 var CP_COMMAND = 0x40;
 var CP_PIXEL_SET = 0x10;
 var CP_PIXEL_SHOW = 0x11;
 var CP_PIXEL_CLEAR = 0x12;
-var CP_TONE        = 0x20;
-var CP_NO_TONE     = 0x21;
+var CP_TONE = 0x20;
+var CP_NO_TONE = 0x21;
+var CP_ACCEL_READ = 0x30;
+var CP_ACCEL_TAP = 0x31;
+var CP_ACCEL_ON = 0x32;
+var CP_ACCEL_OFF = 0x33;
+var CP_ACCEL_TAP_ON = 0x34;
+var CP_ACCEL_TAP_OFF = 0x35;
+var CP_ACCEL_READ_REPLY = 0x36;
+var CP_ACCEL_TAP_REPLY = 0x37;
+var CP_ACCEL_TAP_STREAM_ON = 0x38;
+var CP_ACCEL_TAP_STREAM_OFF = 0x39;
+var CP_ACCEL_STREAM_ON = 0x3A;
+var CP_ACCEL_STREAM_OFF = 0x3B;
+var CP_ACCEL_RANGE = 0x3C;
+var CP_CAP_READ = 0x40;
+var CP_CAP_ON = 0x41;
+var CP_CAP_OFF = 0x42;
+var CP_CAP_REPLY = 0x43;
+
+// Accelerometer constants to be passed to set_accel_range.
+var ACCEL_2G = 0;
+var ACCEL_4G = 1;
+var ACCEL_8G = 2;
+var ACCEL_16G = 3;
+
+// Constants for some of the board peripherals
+var THERM_PIN = 0;  // Analog input connected to the thermistor.
+var THERM_SERIES_OHMS = 10000.0;  // Resistor value in series with thermistor.
+var THERM_NOMINAL_OHMS = 10000.0;  // Thermistor resistance at 25 degrees C.
+var THERM_NOMIMAL_C = 25.0;  // Thermistor temperature at nominal resistance.
+var THERM_BETA = 3950.0;  // Thermistor beta coefficient.
+var CAP_THRESHOLD = 300;  // Threshold for considering a cap touch input pressed.
+// If the cap touch value is above this value it is
+// considered touched.
 
 function Playground(options) {
   Board.call(this, options.port);
+  this.io.sysexResponse(CP_COMMAND, function (data) {
+    var command = data[0] & 0x7F;
+    replyHandlers[command](data);
+  });
 }
+
+var replyHandlers = {};
 
 Playground.prototype = Object.create(Board.prototype, {
   constructor: {
@@ -59,6 +100,77 @@ Playground.Piezo = {
   noTone: {
     value: function() {
       this.io.sysexCommand([CP_COMMAND, CP_NO_TONE]);
+    }
+  }
+};
+
+Playground.parseFirmataByte = function (data) {
+  // Parse a byte value from two 7-bit byte firmata response bytes.
+  if (data.length != 2) {
+    throw('Expected 2 bytes of firmata response for a byte value!');
+  }
+  return (data[0] & 0x7F) | ((data[1] & 0x01) << 7);
+};
+
+/**
+ * Parse a 4 byte floating point value from a 7-bit byte firmata response
+ * byte array.  Each pair of firmata 7-bit response bytes represents a single
+ * byte of float data so there should be 8 firmata response bytes total.
+ * @param {Array} data
+ */
+Playground.parseFirmataFloat = function(data) {
+  return parseFirmata(data, '<f');
+};
+
+Playground.parseFirmataLong = function(data) {
+  return parseFirmata(data, '<l');
+};
+
+function parseFirmata(data, format) {
+  if (data.length != 8) {
+    throw('Expected 8 bytes of firmata response for value to parse.');
+  }
+  //  Convert 2 7-bit bytes in little endian format to 1 8-bit byte for each
+  //    of the four floating point bytes.
+  var rawBytes = new ArrayBuffer(4);
+  for (var i = 0; i < 4; i++) {
+    rawBytes[i] = Playground.parseFirmataByte(data.slice(i * 2, i * 2 + 2));
+  }
+  return bufferpack.unpack(format, rawBytes)[0];
+}
+
+Playground.Gyro = {
+  initialize: {
+    value: function (opts, dataHandler) {
+      console.log("Initializing gyro");
+      this.io.sysexCommand([CP_COMMAND, CP_ACCEL_STREAM_ON]);
+      //this.io.sysexResponse(CP_ACCEL_READ_REPLY & 0x7F, function (data) {
+      // TODO: check for which command response this is?
+      this.io.sysexResponse(CP_COMMAND, function (data) {
+        if (data.length < 26) {
+          console.log('Received accelerometer response with not enough data!')
+          return
+        }
+        var x = Playground.parseFirmataFloat(data.slice(2, 10));
+        var y = Playground.parseFirmataFloat(data.slice(10, 18));
+        var z = Playground.parseFirmataFloat(data.slice(18, 26));
+        var gyroDataObject = {x: x, y: y, z: z};
+        dataHandler(gyroDataObject);
+      });
+    }
+  },
+  toNormal: {
+    // TODO: fill in, verify
+    value: function (raw) {
+      return raw;
+    }
+  },
+  toDegreesPerSecond: {
+    // TODO: fill in, verify
+    value: function (raw) {
+      // TODO: factor in sensitivity
+      //var state = priv.get(this);
+      return raw; /// state.sensitivity;
     }
   }
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -144,8 +144,6 @@ function parseFirmata(data, format) {
 Playground.Gyro = {
   initialize: {
     value: function (opts, dataHandler) {
-      console.log("Initializing gyro");
-      this.io.sysexCommand([CP_COMMAND, CP_ACCEL_STREAM_ON]);
       replyHandlers[CP_ACCEL_READ_REPLY] = function (data) {
         if (data.length < 26) {
           console.log('Received accelerometer response with not enough data!')
@@ -163,6 +161,16 @@ Playground.Gyro = {
     // TODO: fill in, verify
     value: function (raw) {
       return raw;
+    }
+  },
+  start: {
+    value: function () {
+      this.io.sysexCommand([CP_COMMAND, CP_ACCEL_STREAM_ON]);
+    }
+  },
+  stop: {
+    value: function () {
+      this.io.sysexCommand([CP_COMMAND, CP_ACCEL_STREAM_OFF]);
     }
   },
   toDegreesPerSecond: {

--- a/package.json
+++ b/package.json
@@ -7,10 +7,11 @@
     "firmata": "^0.9.0"
   },
   "devDependencies": {
-    "bufferpack": "0.0.6"
+    "bufferpack": "0.0.6",
+    "mocha": "^2.4.5"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha test.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "dependencies": {
     "firmata": "^0.9.0"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "bufferpack": "0.0.6"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Adafruit Circuit Playground IO Plugin",
   "main": "lib/index.js",
   "dependencies": {
-    "firmata": "^0.9.0"
+    "firmata": "rwaldron/firmata#117"
   },
   "devDependencies": {
     "bufferpack": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "bufferpack": "0.0.6",
-    "firmata": "rwaldron/firmata#117"
+    "firmata": "^0.11.3"
   },
   "devDependencies": {
     "mocha": "^2.4.5"

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "Adafruit Circuit Playground IO Plugin",
   "main": "lib/index.js",
   "dependencies": {
+    "bufferpack": "0.0.6",
     "firmata": "rwaldron/firmata#117"
   },
   "devDependencies": {
-    "bufferpack": "0.0.6",
     "mocha": "^2.4.5"
   },
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -62,8 +62,8 @@ board.on("ready", function() {
     freq: 100
   }); 
   
-  var accelerometer = new five.Gyro({
-    controller: Playground.Gyro
+  var accelerometer = new five.Accelerometer({
+    controller: Playground.Accelerometer
   }); 
   
   var tap = new Playground.Tap(io); 

--- a/readme.md
+++ b/readme.md
@@ -15,18 +15,61 @@ Control the Neopixels directly attached to the board.
 ```js
 var Playground = require("playground-io");
 var five = require("johnny-five");
-var board = new five.Board({
-  io: new Playground({
-    port: "/dev/tty.usbmodem1411"
-  })
+var io = new Playground({
+  port: "/dev/tty.usbmodem1411"
 });
+var board = new five.Board({ io: io });
 board.on("ready", function() {
   var pixels = Array.from({ length: 10 }, function(_, index) {
     return new five.Led.RGB({
       controller: Playground.Pixel,
       pin: index
     });
-  });
+  }); 
+  
+  var led = new five.Led(13); 
+  
+  var buttonL = new five.Button('4', {
+    isPullup: true,
+    invert: true
+  }); 
+  
+  var buttonR = new five.Button('19', {
+    isPullup: true,
+    invert: true
+  }); 
+  
+  var toggle = new five.Switch('21'); 
+  
+  var piezo = new five.Piezo({
+    pin: '5',
+    controller: Playground.Piezo
+  }); 
+  
+  var thermometer = new five.Thermometer({
+    controller: "TINKERKIT",
+    pin: "A0",
+    freq: 100
+  }); 
+  
+  var light = new five.Sensor({
+    pin: "A5",
+    freq: 100
+  }); 
+  
+  var sound = new five.Sensor({
+    pin: "A4",
+    freq: 100
+  }); 
+  
+  var accelerometer = new five.Gyro({
+    controller: Playground.Gyro
+  }); 
+  
+  var tap = new Playground.Tap(io); 
+  
+  var touch = new Playground.CapTouch(io);
+
   var index = 0;
   var colors = [
     "red",
@@ -38,13 +81,25 @@ board.on("ready", function() {
     "violet",
   ];
 
-  setInterval(() => {
-    pixels.forEach(pixel => pixel.color(colors[index]));
+  setInterval(function() {
+    pixels.forEach(function(pixel) {
+      pixel.color(colors[index]);
+    });
 
     if (++index === colors.length) {
       index = 0;
     }
   }, 100);
+  
+  tap.onTap(function(single, double) {
+    piezo.frequency(double ? 1500 : 500, 50);
+  });
+  
+  touch.onTouch(10, function(didTouch, value) {
+    if (didTouch) {
+      piezo.frequency(700, 50);
+    }
+  });
 });
 ```
 

--- a/test.js
+++ b/test.js
@@ -1,0 +1,24 @@
+var assert = require('assert');
+var PlaygroundIO = require('./lib');
+
+describe('PlaygroundIO', function () {
+  describe('#parseFirmataFloat()', function () {
+    it('should parse floats from 7-bit byte firmata responses', function () {
+      assert.equal(0.220320343971, PlaygroundIO.parseFirmataFloat([40, 1, 27, 1, 97, 0, 62, 0]).toFixed(12));
+      assert.equal(-0.134108036757, PlaygroundIO.parseFirmataFloat([30, 1, 83, 0, 9, 0, 62, 1]).toFixed(12));
+      assert.equal(13.008480072, PlaygroundIO.parseFirmataFloat([60, 1, 34, 0, 80, 0, 65, 0]).toFixed(9));
+    });
+  });
+
+  describe('#parseFirmataLong()', function () {
+    it('should parse longs from 7-bit byte firmata responses', function () {
+      assert.equal(4, PlaygroundIO.parseFirmataLong([4, 0, 0, 0, 0, 0, 0, 0]));
+    });
+  });
+
+  describe('#parseFirmataByte()', function () {
+    it('should convert', function () {
+      assert.equal(10, PlaygroundIO.parseFirmataByte([10, 0]));
+    });
+  });
+});


### PR DESCRIPTION
This PR adds some basic component support for:
- `Accelerometer` - plugin for `five.Accelerometer`
- `CapTouch` - standalone class taking an `io` instance and exposing an `onTouch(pin, function(isTouch, value){})` callback register
- `Tap` - standalone class taking an `io` instance and exposing an `onTap(function(single, double){})` callback register

Little demo of components in action in Code Studio Applab: https://www.dropbox.com/s/3n1sb8trwwpjyjr/makerlab-demo.screenflow.mp4?dl=0

Not super happy with the separate objects taking in the board `io` object for the `CapTouch` / `Tap` components, wondering if there might be a good component to extend (perhaps `Keypad` for cap touch?) or just a pattern to follow that would let these get registered as first class `five`-managed components themselves?
