### PR TITLE
Pass options object through to Firmata constructor

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -45,7 +45,9 @@ var CAP_THRESHOLD = 300;  // Threshold for considering a cap touch input pressed
 // If the cap touch value is above this value it is considered touched.
 
 function Playground(options) {
-  Firmata.call(this, options.port);
+  var port = options.port;
+  delete options.port;
+  Firmata.call(this, port, options);
 
   // Used to provide private state to this instance
   var state = {

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,12 @@ var Playground = require("playground-io");
 var five = require("johnny-five");
 var board = new five.Board({
   io: new Playground({
-    port: "/dev/tty.usbmodem1411"
+    port: "/dev/tty.usbmodem1411",
+
+    // Passing Firmata options through:
+    // Circuit Playground Firmata seems not to report version before timeout,
+    // lower timeout to reduce initial connection time.
+    reportVersionTimeout: 200
   })
 });
 board.on("ready", function() {


### PR DESCRIPTION
Makes Playground pass its options object through to the Firmata constructor, exposing the Firmata options to consumers of Playground.

This allows us to override the `reportVersionTimeout` (or other Firmata options) which seems to be set way too high for Circuit Playground Firmata.  `reportVersion` never seems to get called - it always waits to the full timeout amount, and we've found it seems to work just fine with timeout values around 200ms and up (much nicer than the default 5000ms).

@bcjordan and I are also investigating how to get Circuit Playground Firmata to proactively report its version making this override unnecessary, but making the options available seemed like a good idea either way.