### PR TITLE
Do not register CP_COMMAND more than once

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -54,17 +54,22 @@ function Playground(options) {
 
   priv.set(this, state);
 
-  this.on("ready", function() {
-    this.sysexResponse(CP_COMMAND, function(data) {
-      var bytes = Firmata.decode(data);
-      var command = bytes.shift();
-      var handler = state.handlers[command];
+  // Firmata stores sysex response handlers statically and throws an error
+  // if you register over one that already exists, so only do this once, ever.
+  if (!Playground.hasRegisteredSysexResponse) {
+    this.on("ready", function() {
+      this.sysexResponse(CP_COMMAND, function(data) {
+        var bytes = Firmata.decode(data);
+        var command = bytes.shift();
+        var handler = state.handlers[command];
 
-      if (typeof handler === "function") {
-        handler(bytes);
-      }
-    });
-  }.bind(this));
+        if (typeof handler === "function") {
+          handler(bytes);
+        }
+      });
+    }.bind(this));
+    Playground.hasRegisteredSysexResponse = true;
+  }
 }
 
 Playground.prototype = Object.create(Firmata.prototype, {

--- a/test/playground.js
+++ b/test/playground.js
@@ -39,6 +39,7 @@ describe("Playground", () => {
 
   beforeEach((done) => {
     sandbox = sinon.sandbox.create();
+    Playground.hasRegisteredSysexResponse = undefined;
     emitter = new Emitter();
     sysexCommand = sandbox.stub(Firmata.prototype, "sysexCommand");
     sysexResponse = sandbox.stub(Firmata.prototype, "sysexResponse");


### PR DESCRIPTION
Firmata caches sysex response handles in a static context, and throws an error if you attempt to register a handler that's already been registered.  Because of this, it's currently impossible to instatiate Playground more than once. I interpret this as a mistake, since Firmata itself _can_ be instantiated more than once.  The tests didn't catch this because they stub the `sysexResponse` method.

Uses a static flag to make sure we only register the CP_COMMAND sysex response once, even if we instantiate multiple Playground instances.