### PR TITLE
Loosen firmata dependency to >=0.11.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "buffer": "^4.6.0",
-    "firmata": "^0.11.3",
+    "firmata": ">=0.11.3",
     "lodash.debounce": "^4.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Opens up the firmata dependency from `^0.11.3` to `>=0.11.3`, allowing playground-io to use later minor versions of firmata including the latest version `0.16.0`.

This mirrors a change in johnny-five to [depend on the `latest` version of firmata](https://github.com/rwaldron/johnny-five/commit/d55c4f276faccf37e0a049d8e5cefbdcb5455a28) (introduced six months ago in 0.10.5).  It's now possible for a project using both johnny-five and playground-io (which is a likely use case) to depend on only one version of firmata, where before it would be using two separate versions.

I'm open to other solutions to this problem, but would like to see playground-io and johnny-five able to use the same firmata version - especially since firmata [keeps some static internal state](https://github.com/rwaldron/playground-io/pull/5), which can lead to subtle bugs when two copies are included in a project.

Tested locally with johnny-five 0.10.10 and firmata 0.16.0.