### PR TITLE
Don't use Firmata.Board

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -47,7 +47,7 @@ var CAP_THRESHOLD = 300;  // Threshold for considering a cap touch input pressed
 function Playground(options) {
   var port = options.port;
   delete options.port;
-  Firmata.Board.call(this, port, options);
+  Firmata.call(this, port, options);
 
   // Used to provide private state to this instance
   var state = {
@@ -76,7 +76,7 @@ function Playground(options) {
 
 Playground.hasRegisteredSysexResponse = false;
 
-Playground.prototype = Object.create(Firmata.Board.prototype, {
+Playground.prototype = Object.create(Firmata.prototype, {
   constructor: {
     value: Playground
   }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "devDependencies": {
     "mocha": "^2.4.5",
+    "proxyquire": "^1.8.0",
     "sinon": "^1.17.4"
   },
   "scripts": {

--- a/test/playground.js
+++ b/test/playground.js
@@ -1,8 +1,13 @@
 var assert = require("assert");
 var Emitter = require("events").EventEmitter;
+var proxyquire = require("proxyquire");
 var sinon = require("sinon");
-var Firmata = require("firmata");
-var Playground = require("../");
+
+// Spy on Firmata dependency when testing Playground
+var Firmata = sinon.spy(require("firmata"));
+var Playground = proxyquire("../", {
+  firmata: Firmata
+});
 
 // Constants that define the Circuit Playground Firmata command values.
 // Must be synced with library source.
@@ -38,6 +43,8 @@ describe("Playground", () => {
   var sysexResponse;
 
   beforeEach((done) => {
+    // Reset Firmata spy (which is outside the sandbox) before every test
+    Firmata.reset();
     sandbox = sinon.sandbox.create();
     Playground.hasRegisteredSysexResponse = false;
     emitter = new Emitter();
@@ -51,11 +58,6 @@ describe("Playground", () => {
   });
 
   describe("constructor", () => {
-    beforeEach((done) => {
-      sandbox.spy(Firmata, 'Board');
-      done();
-    });
-
     it("Forwards a Port and Options", (done) => {
 
       var pg = new Playground({
@@ -63,10 +65,10 @@ describe("Playground", () => {
         reportVersionTimeout: 200
       });
 
-      assert.equal(Firmata.Board.callCount, 1);
-      assert.equal(Firmata.Board.lastCall.args.length, 2);
-      assert.equal(Firmata.Board.lastCall.args[0], emitter);
-      assert.deepEqual(Firmata.Board.lastCall.args[1], { reportVersionTimeout: 200 });
+      assert.equal(Firmata.callCount, 1);
+      assert.equal(Firmata.lastCall.args.length, 2);
+      assert.equal(Firmata.lastCall.args[0], emitter);
+      assert.deepEqual(Firmata.lastCall.args[1], { reportVersionTimeout: 200 });
       pg.on("ready", () => done());
       pg.emit("ready");
     });


### PR DESCRIPTION
Use [proxyquire] and [sinon] to spy on the Firmata constructor when testing Playground, removing dependency on the ([potentially deprecated]) `Firmata.Board` property.

[proxyquire]: https://github.com/thlorenz/proxyquire
[sinon]: https://sinonjs.org
[potentially deprecated]: https://github.com/rwaldron/playground-io/commit/5cb9d7f98bb6c6fde7b5d6394378ea7f8a170e49#commitcomment-22457516